### PR TITLE
Scan for open ports and report failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python-telegram-bot==20.1
+python-telegram-bot[webhooks]==20.1
 python-dotenv==1.1.1
 gspread==6.2.1
 flask==2.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,6 @@ google-auth-httplib2>=0.2.0  # Changed from fixed version to compatible range
 google-auth-oauthlib==1.1.0
 pytz==2023.3.post1
 tzdata==2023.4
+\
+# Ensure webhook server dependency for PTB
+tornado>=6.3


### PR DESCRIPTION
Switch Telegram bot to webhook mode and make service account file path configurable to resolve Render's "No open ports detected" error.

---
<a href="https://cursor.com/background-agent?bcId=bc-09553b42-9395-481c-bf63-f805ebfa9455">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-09553b42-9395-481c-bf63-f805ebfa9455">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

